### PR TITLE
Fix variable enabling enter key event  (#107)

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -556,7 +556,7 @@
 
         $('#start-button').click(() => { handleStartButtonClick() } );
 
-        $(document).keypress( (e) => { ( e.keyCode == 13 && !eventLoopCanEvaluate ) && handleStartButtonClick() } );
+        $(document).keypress( (e) => { ( e.keyCode == 13 && !$("#start-button").attr("disabled") ) && handleStartButtonClick() } );
 
     })();
 


### PR DESCRIPTION
Use `!$("#start-button").attr("disabled")` instead of `!eventLoopCanEvaluate` to allow `handleStartButtonClick()` to be invoked on press of the "enter" key. 

`eventLoopCanEvaluate` is not set until the end of the `addMatterBodiesToSceneAndStartGame()` invocation whereas `$("#start-button").attr("disabled")` is immediately set to true at the beginning of the `handleStartButtonClick()` invocation. 

The delay was allowing `handleStartButtonClick()` to be invoked as many times as the enter key could be pressed before `eventLoopCanEvaluate` was set to false.

Closes #107 