### PR TITLE
Add "UNLICENSED" key to package.json (#122)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "url": "git+https://github.com/matt-eric/three-strike-knockout.git"
   },
   "author": "",
+  "license": "UNLICENSED",
   "bugs": {
     "url": "https://github.com/matt-eric/three-strike-knockout/issues"
   },


### PR DESCRIPTION
A license may be added when all assets are licensed. 

This fixes the warning message in the console when running `yarn build-css`.

<img width="398" alt="Screen Shot 2020-12-11 at 4 50 13 PM" src="https://user-images.githubusercontent.com/24415914/101958306-11563c80-3bd1-11eb-9b67-a2eeffec7406.png">


Closes #122 