### PR TITLE
Set chipPyramidX value based on card size (#114)

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -436,8 +436,11 @@
         launchedChip.collisionFilter.category = chipCategory; //Switch the launchedChip collisionFilter category back to chipCategory to allow the mouse to interact with it.
 
         const successCardPyramid = initializedCardDeck.buildSuccessPyramid();
+
+        let chipPyramidX = .33*window.innerWidth+50; //X-axis coordinate for chip pyramid
+        if (cardsAreLarger) chipPyramidX+=100;
     
-        const successChipPyramid = Composites.pyramid(.33*window.innerWidth+50, -50, 12, 13, 0, 0, (x, y) => {
+        const successChipPyramid = Composites.pyramid(chipPyramidX, -50, 12, 13, 0, 0, (x, y) => {
             return Bodies.circle(x, y, 10, {
                 restitution: 1.4,
                 collisionFilter: {


### PR DESCRIPTION
The `successChipPyramid` is now placed in the center of the `successCardPyramid` for both card sizes.

<img width="1280" alt="Screen Shot 2020-12-11 at 5 20 11 PM" src="https://user-images.githubusercontent.com/24415914/101960427-66944d00-3bd5-11eb-8e1c-6f5814c3ece0.png">

<img width="1280" alt="Screen Shot 2020-12-11 at 5 20 25 PM" src="https://user-images.githubusercontent.com/24415914/101960433-6b590100-3bd5-11eb-8424-ddff78568d94.png">


Closes #114